### PR TITLE
Store MRI data in IndexedDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3443,12 +3443,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3468,7 +3470,8 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -3590,7 +3593,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3616,6 +3620,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4645,6 +4650,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "idb-keyval": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-3.1.0.tgz",
+      "integrity": "sha512-iFwFN5n00KNNnVxlOOK280SJJfXWY7pbMUOQXdIXehvvc/mGCV/6T2Ae+Pk2KwAkkATDTwfMavOiDH5lrJKWXQ=="
     },
     "ieee754": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.26.0",
+    "idb-keyval": "^3.1.0",
     "nifti-js": "^1.0.1",
     "pako": "^1.0.6"
   }

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ import 'babel-polyfill';
 import nifti from 'nifti-js';
 import pako from 'pako';
 import MRISlice from './mri-volume-slice';
+import * as idb from 'idb-keyval';
 
 const mRISlice = new MRISlice();
 
@@ -36,6 +37,7 @@ document.getElementById('toggle-cross-hairs').onchange = (event) => {
 };
 
 function setupNifti(file) {
+  idb.set("LastNiftiFile", file);
   mRISlice.loadNewNifti(nifti.parse(file));
   mRISlice.mouseNavigationEnabled('enable please');
   hideLoader();
@@ -48,6 +50,8 @@ function hideLoader() {
 
 
 async function loadDefaultData() {
+  const lastFile = await idb.get("LastNiftiFile");
+  if (lastFile) return setupNifti(lastFile);
   const url = 'https://openneuro.org/crn/datasets/ds001417/files/sub-study002:ses-after:anat:sub-study002_ses-after_T1w.nii.gz';
   const response = await fetch(url);
   const blob = await response.arrayBuffer();


### PR DESCRIPTION
#28 A simple solution for MRI data store and recover, just 4 lines and <1KB dependency.

Use of Local Storage is possible if data was smaller, for this purpose I think IndexedDB is the best solution allowing to save up to 50MB without any confirmation and with more browser support than alternative solution provided by @mkeeneth in #29, a very good solution when more browser support it by the way.